### PR TITLE
Fix MAUI build errors

### DIFF
--- a/KTMConnectedMaui/App.xaml
+++ b/KTMConnectedMaui/App.xaml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="KTMConnectedMaui.App">
 </Application>

--- a/KTMConnectedMaui/KTMConnectedMaui.csproj
+++ b/KTMConnectedMaui/KTMConnectedMaui.csproj
@@ -8,6 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Plugin.BLE" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+    <PackageReference Include="Plugin.BLE" Version="3.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add the missing `xmlns:x` namespace in `App.xaml`
- reference Microsoft.Maui.Controls and update Plugin.BLE version

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_687fae1532cc8325958da62e745be57e