### PR TITLE
Use classic Bluetooth on Android

### DIFF
--- a/KTMConnectedMaui/KTMConnectedMaui.csproj
+++ b/KTMConnectedMaui/KTMConnectedMaui.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-ios</TargetFrameworks>
+    <TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
@@ -9,6 +9,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
-    <PackageReference Include="Plugin.BLE" Version="3.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- switch MAUI project to target Android as well as iOS
- remove Plugin.BLE dependency
- reimplement `BluetoothManager` using Android's `BluetoothSocket`

## Testing
- `dotnet build KTMConnectedMaui/KTMConnectedMaui.csproj` *(fails: The target platform identifier ios was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_687fd45bc48883259898bdb4a6416405