### PR TITLE
Use MFi connection for KTM MAUI client

### DIFF
--- a/KTMConnectedMaui/KTMConnectedMaui.csproj
+++ b/KTMConnectedMaui/KTMConnectedMaui.csproj
@@ -9,6 +9,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
-    <PackageReference Include="InTheHand.Net.Bluetooth" Version="4.2.2" />
   </ItemGroup>
 </Project>

--- a/KTMConnectedMaui/Platforms/iOS/Info.plist
+++ b/KTMConnectedMaui/Platforms/iOS/Info.plist
@@ -6,11 +6,15 @@
 	<string>This app needs Bluetooth access to connect to KTM devices</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>This app needs Bluetooth access to connect to KTM devices</string>
-	<key>CFBundleIdentifier</key>
-	<string>com.APDSoftware.KTMConntectedMaui</string>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>fetch</string>
-	</array>
+        <key>CFBundleIdentifier</key>
+        <string>com.APDSoftware.KTMConntectedMaui</string>
+        <key>UISupportedExternalAccessoryProtocols</key>
+        <array>
+                <string>com.ktm.myride</string>
+        </array>
+        <key>UIBackgroundModes</key>
+        <array>
+                <string>fetch</string>
+        </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- remove InTheHand.Net dependency
- add ExternalAccessory-based BluetoothManager
- declare supported accessory protocol in iOS Info.plist

## Testing
- `dotnet workload restore KTMConnectedMaui/KTMConnectedMaui.csproj`
- `dotnet build KTMConnectedMaui/KTMConnectedMaui.csproj` *(fails: NETSDK1139 target platform identifier ios was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_687ff2f93b98832592edd16e9c74fa82